### PR TITLE
add a blur timeout so form button clicks work

### DIFF
--- a/jquery.elastic.source.js
+++ b/jquery.elastic.source.js
@@ -148,13 +148,16 @@
 				
 				// Compact textarea on blur
 				$textarea.bind('blur',function(){
-					if($twin.height() < maxheight){
-						if($twin.height() > minheight) {
-							$textarea.height($twin.height());
-						} else {
-							$textarea.height(minheight);
+					function compact(){
+						if($twin.height() < maxheight){
+							if($twin.height() > minheight) {
+								$textarea.height($twin.height());
+							} else {
+								$textarea.height(minheight);
+							}
 						}
 					}
+					setTimeout(compact, 500);
 				});
 				
 				// And this line is to catch the browser paste event


### PR DESCRIPTION
if the blur event is triggered while a user is clicking on a form submission button, the blur callback fires however the button click is never picked up so the form is never submitted. This patchset would make the blur callback occur after 500ms. This value is arbitrary as it just needs to be long enough to allow the button to fire its own event. It's possible some other timeout value would be more correct.